### PR TITLE
修倒數閃爍 + 回報帶題號(issue form) + 換題動畫

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 考生討論 / 一般問題
+    url: https://github.com/yazelin/ipas-ai-quiz/discussions
+    about: 想跟其他考生交流,或非「題目錯誤」的問題,請到討論區。

--- a/.github/ISSUE_TEMPLATE/question-report.yml
+++ b/.github/ISSUE_TEMPLATE/question-report.yml
@@ -1,0 +1,42 @@
+name: 題目回報
+description: 回報題庫答案錯誤、選項缺漏或解析有誤
+title: "[題目回報] "
+labels: ["question-report"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        感謝幫忙把題庫養乾淨。從題卡的「這題有誤?」點進來時,題號會自動帶入。
+  - type: input
+    id: qid
+    attributes:
+      label: 題號
+      description: 題目 id(從題卡點進來會自動填);手動回報請填,例如 115-1-b-s1-q3
+      placeholder: 115-1-b-s1-q3
+    validations:
+      required: true
+  - type: input
+    id: subject
+    attributes:
+      label: 科目(選填)
+      placeholder: "科目1:人工智慧基礎概論"
+  - type: dropdown
+    id: kind
+    attributes:
+      label: 問題類型
+      options:
+        - 正解標錯
+        - 選項文字有誤或缺漏
+        - 題幹抽錯行 / 有亂碼
+        - 解析有誤
+        - 其他
+    validations:
+      required: true
+  - type: textarea
+    id: detail
+    attributes:
+      label: 說明
+      description: 哪裡怪?你認為正確答案是什麼?(附官方依據更好)
+      placeholder: "例如:這題正解應該是 (C);官方答案公告第 12 題標 C。"
+    validations:
+      required: true

--- a/app.js
+++ b/app.js
@@ -168,11 +168,11 @@ function guideLine(q) {
   const link = url ? ` <a href="${esc(url)}" target="_blank" rel="noopener">開啟學習指引 ↗</a>` : '';
   return `<p class="guide">教材對應：${esc(q.subject)} ${ch}${link}</p>`;
 }
-// 回報這題（開 GitHub issue，帶好題目 id）
+// 回報這題：開 GitHub issue form,自動帶入題號與科目
 function reportLink(q) {
-  const title = encodeURIComponent(`[題目回報] ${q.id}`);
-  const body = encodeURIComponent(`題目 ID:${q.id}\n科目：${q.subject}\n\n我覺得這題有問題（請描述，例如答案/選項/解析有誤）:\n`);
-  return `<p class="report-line"><a href="https://github.com/yazelin/ipas-ai-quiz/issues/new?labels=question-report&title=${title}&body=${body}" target="_blank" rel="noopener">這題有誤？回報給作者</a></p>`;
+  const url = `https://github.com/yazelin/ipas-ai-quiz/issues/new?template=question-report.yml`
+    + `&qid=${encodeURIComponent(q.id)}&subject=${encodeURIComponent(q.subject)}`;
+  return `<p class="report-line"><a href="${url}" target="_blank" rel="noopener">這題有誤？回報給作者</a></p>`;
 }
 // 今日挑戰：用日期當種子，固定挑 3 題（每天不同、當天穩定）
 function dailyChallenge() {
@@ -412,10 +412,11 @@ function runMock(pool, mins) {
   const answers = new Array(pool.length).fill(null);
   let i = 0;
   let remaining = mins * 60;
+  const fmt = () => `${String((remaining / 60) | 0).padStart(2, '0')}:${String(remaining % 60).padStart(2, '0')}`;
   const timer = setInterval(() => {
     remaining--;
     const t = $('#timer');
-    if (t) t.textContent = `${String((remaining / 60) | 0).padStart(2, '0')}:${String(remaining % 60).padStart(2, '0')}`;
+    if (t) t.textContent = fmt();
     if (remaining <= 0) { clearInterval(timer); submit(); }
   }, 1000);
 
@@ -423,7 +424,7 @@ function runMock(pool, mins) {
     const q = pool[i];
     view.innerHTML = `
       <section class="card">
-        <div class="row"><span class="muted">${i + 1} / ${pool.length}</span><span id="timer" class="timer">--:--</span></div>
+        <div class="row"><span class="muted">${i + 1} / ${pool.length}</span><span id="timer" class="timer">${fmt()}</span></div>
         <p class="qmeta muted">${esc(q.subject)}</p>
         <h3>${esc(q.question)}</h3>
         ${q.image ? `<img class="qfig" src="${esc(q.image)}" alt="題目附圖" loading="lazy">` : ''}
@@ -434,7 +435,11 @@ function runMock(pool, mins) {
           ${i + 1 < pool.length ? '<button id="next">下一題</button>' : '<button class="primary" id="submit">交卷</button>'}
         </div>
       </section>`;
-    view.querySelectorAll('.opt').forEach((b) => (b.onclick = () => { answers[i] = +b.dataset.k; render(); }));
+    // 點選項只切換 picked class,不整卡重 render(否則 #timer 被重建會閃 --:--)
+    view.querySelectorAll('.opt').forEach((b) => (b.onclick = () => {
+      answers[i] = +b.dataset.k;
+      view.querySelectorAll('.opt').forEach((x) => x.classList.toggle('picked', +x.dataset.k === answers[i]));
+    }));
     if ($('#prev')) $('#prev').onclick = () => { i--; render(); };
     if ($('#next')) $('#next').onclick = () => { i++; render(); };
     if ($('#submit')) $('#submit').onclick = submit;
@@ -605,8 +610,8 @@ function settings() {
       insBtn.disabled = true;
       insBtn.textContent = '由瀏覽器選單安裝';
       insMsg.textContent = /iphone|ipad|ipod/i.test(navigator.userAgent)
-        ? '(iPhone:Safari 分享鈕 → 加入主畫面)'
-        : '(Chrome ⋮ 選單 → 安裝應用程式 / 加到主畫面)';
+        ? '（iPhone:Safari 分享鈕 → 加入主畫面）'
+        : '（Chrome ⋮ 選單 → 安裝應用程式 / 加到主畫面）';
     }
   }
   $('#set-goal').onchange = (e) => { store.settings ||= {}; store.settings.dailyGoal = Math.max(1, +e.target.value || 20); save(); };

--- a/index.html
+++ b/index.html
@@ -42,14 +42,16 @@
   nav button { border:0; background:none; padding:8px 12px; border-radius:8px; color:var(--c-muted); font-size:15px; cursor:pointer; }
   nav button.on { background:var(--c-card); color:var(--c-accent); font-weight:600; box-shadow:0 1px 2px rgba(0,0,0,.06); }
   main { max-width:720px; margin:0 auto; padding:8px 12px 48px; }
-  .card { background:var(--c-card); border:1px solid var(--c-line); border-radius:14px; padding:20px; margin-bottom:16px; }
+  .card { background:var(--c-card); border:1px solid var(--c-line); border-radius:14px; padding:20px; margin-bottom:16px; animation:card-in .18s ease both; }
+  @keyframes card-in { from { opacity:0; transform:translateY(6px); } to { opacity:1; transform:none; } }
   h2 { margin-top:0; }
   .muted { color:var(--c-muted); }
   label { display:block; margin:12px 0 4px; font-size:14px; }
   select, input, textarea { width:100%; padding:10px; border:1px solid var(--c-line); border-radius:8px; font-size:15px; font-family:inherit; }
   button.primary { background:var(--c-accent); color:#fff; border:0; padding:12px 18px; border-radius:10px; font-size:16px; cursor:pointer; margin-top:14px; }
   .card > button:not(.primary) { background:#eef0f3; border:0; padding:10px 14px; border-radius:8px; font-size:14px; cursor:pointer; margin:8px 8px 0 0; }
-  .opt { display:block; width:100%; text-align:left; padding:12px 14px; margin:8px 0; border:1px solid var(--c-line); border-radius:10px; background:#fff; font-size:15px; cursor:pointer; }
+  .opt { display:block; width:100%; text-align:left; padding:12px 14px; margin:8px 0; border:1px solid var(--c-line); border-radius:10px; background:#fff; font-size:15px; cursor:pointer; transition:background .12s, border-color .12s, transform .06s; }
+  .opt:active { transform:scale(.99); }
   .opt:hover { border-color:var(--c-accent); }
   .opt.correct { border-color:var(--c-ok); background:#f0fdf4; }
   .opt.wrong { border-color:var(--c-bad); background:#fef2f2; }
@@ -108,6 +110,7 @@
   .code { font-family:ui-monospace,monospace; font-size:20px; background:#f8fafc; padding:10px; border-radius:8px; text-align:center; letter-spacing:1px; }
   h3.danger, button.danger { color:var(--c-bad); }
   button.danger { border:1px solid var(--c-bad)!important; background:#fff!important; }
+  @media (prefers-reduced-motion: reduce) { .card { animation:none; } .opt { transition:none; } .opt:active { transform:none; } }
 </style>
 </head>
 <body>
@@ -130,7 +133,7 @@
   <footer class="site-footer">
     <nav>
       <a href="https://github.com/yazelin/ipas-ai-quiz/discussions" target="_blank" rel="noopener">考生討論區</a>
-      <a href="https://github.com/yazelin/ipas-ai-quiz/issues/new?labels=question-report&title=%5B%E9%A1%8C%E7%9B%AE%E5%9B%9E%E5%A0%B1%5D" target="_blank" rel="noopener">回報題目</a>
+      <a href="https://github.com/yazelin/ipas-ai-quiz/issues/new?template=question-report.yml" target="_blank" rel="noopener">回報題目</a>
       <a href="https://github.com/yazelin/ipas-ai-quiz" target="_blank" rel="noopener">GitHub 原始碼</a>
       <a href="https://www.facebook.com/yaze.lin.gm" target="_blank" rel="noopener">Facebook</a>
       <a href="https://buymeacoffee.com/yazelin" target="_blank" rel="noopener">請我喝咖啡</a>

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // 離線快取:app shell + 題庫。stale-while-revalidate(先給快取、背景更新)。
 // 改版要更新快取時,把 CACHE 版號 +1。
-const CACHE = 'ipas-v14';
+const CACHE = 'ipas-v15';
 const SHELL = ['./', 'index.html', 'app.js', 'core.js', 'manifest.json', 'favicon.svg', 'questions.json', 'concepts.json', 'icon-192.png', 'icon-512.png'];
 
 self.addEventListener('install', (e) => {


### PR DESCRIPTION
回應使用者回饋(留言反映的 UX 問題)。

## 改動
- **倒數閃爍**:模擬考點選項原本整卡重 render → `#timer` 被重建成 `--:--` 等下一秒才填回。改成點選項只 toggle `.picked` class、不重 render;timer 一律用當前秒數算字串。
- **題目回報帶題號**:新增 `.github/ISSUE_TEMPLATE/question-report.yml`(結構化 issue form:題號/科目/類型/說明)+ `config.yml`(非題目錯誤導向 Discussions)。題卡「這題有誤?」連結自動帶入 `&qid=<題號>&subject=<科目>`。
- **標點殘留**:清掉 2 行安裝提示的半形括號夾中文。
- **動畫**:換題/換頁卡片淡入 + 選項點擊回饋,`prefers-reduced-motion` 下停用。
- `sw.js` CACHE v14→v15。

## 瀏覽器實測(headless)
- 點選項:timer 維持 `90:00`、`flickerOnPick=false`、`.picked` 正確
- 換題:`flickerOnNext=false`
- 回報連結:`...?template=question-report.yml&qid=114-4-b-s1-q3&subject=科目1：人工智慧基礎概論`
- 所有資源 200、card 動畫 `card-in` 生效
- `node --check app.js` OK、`core.test.mjs` PASS、YAML 合法

> issue form 是 AI 草的,建議 merge 後你親自走一次回報流程確認體驗(如回饋所提)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)