### PR TITLE
「筆記」分頁:集中看/編輯筆記 + 匯出不漏

### DIFF
--- a/app.js
+++ b/app.js
@@ -486,6 +486,31 @@ function wrongbook() {
   if (ids.length) $('#drill').onclick = () => runPractice(shuffle(list));
 }
 
+function notes() {
+  setNav('notes');
+  const items = DATA.questions.filter((q) => { const p = store.q[q.id]; return p && (p.note || p.starred); });
+  view.innerHTML = `
+    <section class="card">
+      <h2>我的筆記</h2>
+      <p class="muted">有寫筆記、或加星 ⭐ 的題目都在這。筆記可直接在下面改,會自動存。</p>
+      ${items.length
+        ? '<button id="exp-notes">匯出筆記（Markdown）</button>'
+        : '<p>還沒有筆記或星標題。練習時在題目下方寫筆記、或點 ☆ 加星,就會出現在這。</p>'}
+      ${items.map((q) => {
+        const p = qp(q.id);
+        return `<div class="note-item">
+          <div class="row"><span class="muted">${p.starred ? '⭐ ' : ''}${esc(q.subject)}</span>
+            <button class="goto" data-id="${esc(q.id)}">前往該題</button></div>
+          <p class="qn">${esc(q.question)}</p>
+          <textarea class="note-edit" data-id="${esc(q.id)}" rows="2" placeholder="寫下你的理解或記憶點…">${esc(p.note || '')}</textarea>
+        </div>`;
+      }).join('')}
+    </section>`;
+  view.querySelectorAll('.note-edit').forEach((t) => (t.oninput = (e) => { qp(e.target.dataset.id).note = e.target.value; save(); }));
+  view.querySelectorAll('.goto').forEach((b) => (b.onclick = () => { const q = DATA.questions.find((x) => x.id === b.dataset.id); if (q) runPractice([q]); }));
+  if (items.length) $('#exp-notes').onclick = () => download('ipas-notes.md', toMarkdown(DATA.questions, store.q), 'text/markdown');
+}
+
 function stats() {
   setNav('stats');
   const s = progressStats(DATA.questions, store.q);
@@ -591,7 +616,7 @@ function settings() {
       <button id="exp">匯出進度（JSON）</button>
       <button id="imp-btn">匯入進度（JSON）</button>
       <input id="imp" type="file" accept="application/json" hidden>
-      <button id="exp-md">匯出星標筆記（Markdown）</button>
+      <button id="exp-md">匯出筆記（Markdown）</button>
 
       <h3 class="danger">重設</h3>
       <button class="danger" id="reset">清除本機所有進度</button>
@@ -677,7 +702,7 @@ function settings() {
   };
 }
 
-const ROUTES = { home, mock: mockSetup, wrong: wrongbook, stats, settings };
+const ROUTES = { home, mock: mockSetup, wrong: wrongbook, notes, stats, settings };
 
 // ---- boot ----
 async function boot() {

--- a/core.js
+++ b/core.js
@@ -71,13 +71,13 @@ export function wrongQuestionIds(questions, progress) {
     .map((q) => q.id);
 }
 
-// 把星標題 + 解析 + 筆記整理成 markdown,供匯出。
-export function toMarkdown(questions, progress, title = 'iPAS 錯題筆記') {
+// 把「有星標或有筆記」的題 + 解析 + 筆記整理成 markdown,供匯出。
+export function toMarkdown(questions, progress, title = 'iPAS 筆記') {
   const lines = [`# ${title}`, ''];
   let n = 0;
   for (const q of questions) {
     const p = progress[q.id];
-    if (!p || !p.starred) continue;
+    if (!p || (!p.starred && !p.note)) continue;
     n++;
     lines.push(`## ${n}. [${q.subject}] ${q.question}`);
     lines.push(`- 正解：${q.options[q.answer]}`);

--- a/core.test.mjs
+++ b/core.test.mjs
@@ -41,11 +41,16 @@ const s1 = st.subjects.find((s) => s.subject === 'S1');
 assert.equal(s1.accuracy, 71.4); // 5 correct / 7 attempts
 assert.deepEqual(wrongQuestionIds(qs, prog), ['b']);
 
-// markdown 匯出(只收星標)
+// markdown 匯出(收星標)
 const md = toMarkdown(qs, { c: { starred: true, note: '記得 RAG' } });
 assert.ok(md.includes('[S2]'));
 assert.ok(md.includes('正解：y'));
 assert.ok(md.includes('我的筆記：記得 RAG'));
-assert.ok(!md.includes('qa'), '沒星標的不該出現');
+assert.ok(!md.includes('qa'), '沒星標也沒筆記的不該出現');
+
+// 有筆記但沒星標也要收(筆記不漏)
+const md2 = toMarkdown(qs, { a: { note: '只有筆記沒星標' } });
+assert.ok(md2.includes('只有筆記沒星標'), '有筆記就該收');
+assert.ok(md2.includes('qa'));
 
 console.log('PASS');

--- a/index.html
+++ b/index.html
@@ -103,6 +103,10 @@
   .concept-card .ck { font-size:12px; color:var(--c-accent); font-weight:600; }
   .concept-card h3 { margin:4px 0 6px; }
   .report-line a { font-size:12px; color:var(--c-muted); }
+  .note-item { border-top:1px solid var(--c-line); padding-top:12px; margin-top:12px; }
+  .note-item .qn { font-size:14px; margin:6px 0; }
+  .note-item .goto { background:#eef0f3; border:0; padding:4px 10px; border-radius:6px; font-size:13px; cursor:pointer; white-space:nowrap; }
+  .note-edit { margin-top:4px; }
   .badges { display:flex; flex-wrap:wrap; gap:8px; margin:6px 0 14px; }
   .badge { font-size:13px; padding:6px 10px; border-radius:999px; background:#ecfdf5; color:#047857; border:1px solid #a7f3d0; }
   .badge.lock { background:#f3f4f6; color:#9ca3af; border-color:#e5e7eb; }
@@ -123,6 +127,7 @@
       <button data-v="home" class="on">練習</button>
       <button data-v="mock">模擬考</button>
       <button data-v="wrong">錯題本</button>
+      <button data-v="notes">筆記</button>
       <button data-v="stats">統計</button>
       <button data-v="settings">設定</button>
     </nav>

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // 離線快取:app shell + 題庫。stale-while-revalidate(先給快取、背景更新)。
 // 改版要更新快取時,把 CACHE 版號 +1。
-const CACHE = 'ipas-v16';
+const CACHE = 'ipas-v17';
 const SHELL = ['./', 'index.html', 'app.js', 'core.js', 'manifest.json', 'favicon.svg', 'questions.json', 'concepts.json', 'icon-192.png', 'icon-512.png'];
 
 self.addEventListener('install', (e) => {


### PR DESCRIPTION
回應使用者:寫的筆記沒地方集中看(且匯出只收星標、沒加星的筆記等於消失)。

## 改動
- **新增「筆記」分頁**:列出所有「有筆記或星標 ⭐」的題;筆記可直接就地編輯(自動存)、可「前往該題」跳回練習。
- **修匯出漏洞**:`toMarkdown` 由「只收星標」→「星標或有筆記都收」。沒加星的筆記不再從 Markdown 匯出消失。
- 設定的匯出鈕「匯出星標筆記」→「匯出筆記」;`core.test.mjs` 補「有筆記沒星標也要收」案例。
- `sw.js` CACHE v16→v17。

## 瀏覽器實測(headless)
- 種「有筆記沒星標」+「有星標沒筆記」兩筆 → 筆記分頁正確列出 2 筆(前者正是先前看不到的 gap)
- 就地編輯 textarea → 寫進 localStorage ✓
- 「前往該題」→ 跳到該題練習 ✓
- 匯出鈕在;`core.test.mjs` PASS、`node --check` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)