### PR TITLE
意見回饋表單自動帶入裝置/瀏覽器

### DIFF
--- a/app.js
+++ b/app.js
@@ -702,11 +702,25 @@ function settings() {
   };
 }
 
+// 從 UA 粗略判斷裝置/瀏覽器,給「意見回饋」表單預填(僅 OS + 瀏覽器名,不含版本)
+function deviceLabel() {
+  const ua = navigator.userAgent;
+  const os = /iPhone/.test(ua) ? 'iPhone' : /iPad/.test(ua) ? 'iPad' : /Android/.test(ua) ? 'Android'
+    : /Windows/.test(ua) ? 'Windows' : /Macintosh|Mac OS X/.test(ua) ? 'Mac' : /Linux/.test(ua) ? 'Linux' : '其他';
+  const br = /Edg\//.test(ua) ? 'Edge' : /SamsungBrowser/.test(ua) ? 'Samsung Internet'
+    : /CriOS|Chrome\//.test(ua) ? 'Chrome' : /FxiOS|Firefox\//.test(ua) ? 'Firefox'
+    : /Version\/[\d.]+.*Safari/.test(ua) ? 'Safari' : '瀏覽器';
+  return `${os} · ${br}`;
+}
+
 const ROUTES = { home, mock: mockSetup, wrong: wrongbook, notes, stats, settings };
 
 // ---- boot ----
 async function boot() {
   document.querySelectorAll('nav button').forEach((b) => (b.onclick = () => ROUTES[b.dataset.v]()));
+  // 「意見回饋」連結自動帶入裝置/瀏覽器(GitHub issue form 以 &env= 預填同名欄位)
+  const fbLink = document.getElementById('fb-link');
+  if (fbLink) fbLink.href += `&env=${encodeURIComponent(deviceLabel())}`;
   if (isStandalone() || installBarOff()) { const b = document.getElementById('installbar'); if (b) b.hidden = true; }
   const ib = document.getElementById('install-btn');
   if (ib) ib.onclick = async () => {

--- a/index.html
+++ b/index.html
@@ -140,7 +140,7 @@
   <footer class="site-footer">
     <nav>
       <a href="https://github.com/yazelin/ipas-ai-quiz/discussions" target="_blank" rel="noopener">考生討論區</a>
-      <a href="https://github.com/yazelin/ipas-ai-quiz/issues/new?template=feedback.yml" target="_blank" rel="noopener">意見回饋</a>
+      <a id="fb-link" href="https://github.com/yazelin/ipas-ai-quiz/issues/new?template=feedback.yml" target="_blank" rel="noopener">意見回饋</a>
       <a href="https://github.com/yazelin/ipas-ai-quiz" target="_blank" rel="noopener">GitHub 原始碼</a>
       <a href="https://www.facebook.com/yaze.lin.gm" target="_blank" rel="noopener">Facebook</a>
       <a href="https://buymeacoffee.com/yazelin" target="_blank" rel="noopener">請我喝咖啡</a>

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // 離線快取:app shell + 題庫。stale-while-revalidate(先給快取、背景更新)。
 // 改版要更新快取時,把 CACHE 版號 +1。
-const CACHE = 'ipas-v17';
+const CACHE = 'ipas-v18';
 const SHELL = ['./', 'index.html', 'app.js', 'core.js', 'manifest.json', 'favicon.svg', 'questions.json', 'concepts.json', 'icon-192.png', 'icon-512.png'];
 
 self.addEventListener('install', (e) => {


### PR DESCRIPTION
回應使用者:feedback 表單的「裝置 / 瀏覽器」欄位能否自動帶入。

GitHub issue form 支援用網址 query param 預填同名欄位(`id: env`)。footer「意見回饋」是靜態連結,改由 JS 在載入時偵測 UA 補上 `&env=`。

- `deviceLabel()` 從 UA 判 OS + 瀏覽器(iPhone · Safari、Windows · Chrome…),只帶名稱不含版本
- footer link 加 `id="fb-link"`,boot 時 append `&env=<encodeURIComponent(label)>`
- 欄位仍為選填、使用者可改;`sw.js` CACHE v17→v18

## 實測(headless)
- `fb-link` href = `...?template=feedback.yml&env=Linux%20·%20Chrome`,`env` 解碼 = `Linux · Chrome`
- `node --check` OK、`core.test.mjs` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)