### PR TITLE
練習模式做完加結算頁

### DIFF
--- a/app.js
+++ b/app.js
@@ -340,6 +340,8 @@ function home() {
 
 function runPractice(pool, opts = {}) {
   let i = 0;
+  let right = 0, wrong = 0;
+  const sessionWrong = [];
   if (!pool.length) {
     view.innerHTML = `<section class="card"><p>沒有符合的題目。</p></section>`;
     return;
@@ -365,7 +367,7 @@ function runPractice(pool, opts = {}) {
     const p = qp(q.id);
     const correct = k === q.answer;
     p.attempts++;
-    if (correct) p.correct++; else p.wrong++;
+    if (correct) { p.correct++; right++; } else { p.wrong++; wrong++; sessionWrong.push(q); }
     p.box = nextBox(p.box, correct);
     logRecent(correct);
     bumpDaily(correct);
@@ -383,7 +385,23 @@ function runPractice(pool, opts = {}) {
       <label class="note">筆記<textarea id="note" rows="2" placeholder="寫下你的理解或記憶點…">${esc(p.note || '')}</textarea></label>
       <button class="primary" id="next">${i + 1 < pool.length ? '下一題' : '完成'}</button>`;
     $('#note').oninput = (e) => { p.note = e.target.value; save(); };
-    $('#next').onclick = () => { i++; i < pool.length ? render() : home(); };
+    $('#next').onclick = () => { i++; i < pool.length ? render() : finish(); };
+  };
+  const finish = () => {
+    const total = right + wrong;
+    const pct = total ? Math.round((right / total) * 1000) / 10 : 0;
+    view.innerHTML = `
+      <section class="card">
+        <h2>練習完成</h2>
+        <p class="score">${pct}％</p>
+        <p>這組 ${total} 題,答對 ${right}、答錯 ${wrong}</p>
+        ${sessionWrong.length ? '<button class="primary" id="redo-wrong">只練這次錯的</button>' : '<p class="muted">這組全對,讚!</p>'}
+        <button id="again">再練一次</button>
+        <button id="back">回首頁</button>
+      </section>`;
+    if (sessionWrong.length) $('#redo-wrong').onclick = () => runPractice(sessionWrong.slice());
+    $('#again').onclick = () => runPractice(shuffle(pool.slice()));
+    $('#back').onclick = home;
   };
   render();
 }

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // 離線快取:app shell + 題庫。stale-while-revalidate(先給快取、背景更新)。
 // 改版要更新快取時,把 CACHE 版號 +1。
-const CACHE = 'ipas-v18';
+const CACHE = 'ipas-v19';
 const SHELL = ['./', 'index.html', 'app.js', 'core.js', 'manifest.json', 'favicon.svg', 'questions.json', 'concepts.json', 'icon-192.png', 'icon-512.png'];
 
 self.addEventListener('install', (e) => {


### PR DESCRIPTION
回應使用者(土川):練習做完沒有總結、直接跳回一開始的畫面有點怪。

模擬考本來就有結算頁,練習模式沒有(答完最後一題直接 `home()`)。補上對齊的結算。

## 改動
- `runPractice` 加 session 計數(right/wrong/sessionWrong),完成最後一題後顯示結算頁:正確率、這組題數、答對/答錯。
- 按鈕:**只練這次錯的**(沒錯則顯示「全對」)/ **再練一次**(同範圍洗牌)/ **回首頁**。
- `sw.js` CACHE v18→v19。

## 實測(headless)
- 練習答完 → 顯示「練習完成 0％ 這組 3 題,答對 0、答錯 3」+ 三顆按鈕,不再跳首頁
- 「只練這次錯的」→ 進入只含錯題的練習(1 / 3)
- `node --check` OK、`core.test.mjs` PASS、無 JS console error

🤖 Generated with [Claude Code](https://claude.com/claude-code)