### PR TITLE
首頁加「只練看圖題」入口

### DIFF
--- a/app.js
+++ b/app.js
@@ -295,6 +295,7 @@ function home() {
         <select id="pr-count"><option value="10">10</option><option value="20">20</option><option value="0">全部（選取範圍）</option></select>
       </label>
       <button class="primary" id="pr-start">開始練習</button>
+      <button id="pr-images">只練看圖題（${DATA.questions.filter((q) => q.image).length} 題,全中級）</button>
     </section>`;
   const selectedKeys = () => new Set([...view.querySelectorAll('.rng:checked')].map((c) => c.value));
   const kw = () => $('#pr-kw').value.trim().toLowerCase();
@@ -328,6 +329,7 @@ function home() {
     if (count) pool = pool.slice(0, count);
     runPractice(pool);
   };
+  $('#pr-images').onclick = () => runPractice(shuffle(DATA.questions.filter((q) => q.image)));
   $('#challenge').onclick = () => { store.challengeDone = today(); save(); runPractice(dailyChallenge()); };
   $('#share').onclick = async () => {
     const txt = `我在 iPAS AI 應用規劃師模擬考刷題：連續打卡 ${strk} 天、今日 ${dc}/${g} 題。一起來練歷屆考古題！`;

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // 離線快取:app shell + 題庫。stale-while-revalidate(先給快取、背景更新)。
 // 改版要更新快取時,把 CACHE 版號 +1。
-const CACHE = 'ipas-v20';
+const CACHE = 'ipas-v21';
 const SHELL = ['./', 'index.html', 'app.js', 'core.js', 'manifest.json', 'favicon.svg', 'questions.json', 'concepts.json', 'icon-192.png', 'icon-512.png'];
 
 self.addEventListener('install', (e) => {


### PR DESCRIPTION
回應使用者:帶圖題全集中在中級,沒有獨立入口、不容易遇到/複習。練習卡加一顆「只練看圖題（35 題,全中級）」,一鍵練全部帶圖題。

實測:按鈕 → 進入練習池 1 / 35、第一題即顯示附圖。sw.js CACHE v20→v21。

🤖 Generated with [Claude Code](https://claude.com/claude-code)