### PR TITLE
footer 加「官方考試資訊」連結

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,6 +139,7 @@
   <main id="view"></main>
   <footer class="site-footer">
     <nav>
+      <a href="https://ipd.nat.gov.tw/ipas/certification/AIAP/exam-info" target="_blank" rel="noopener">官方考試資訊</a>
       <a href="https://github.com/yazelin/ipas-ai-quiz/discussions" target="_blank" rel="noopener">考生討論區</a>
       <a id="fb-link" href="https://github.com/yazelin/ipas-ai-quiz/issues/new?template=feedback.yml" target="_blank" rel="noopener">意見回饋</a>
       <a href="https://github.com/yazelin/ipas-ai-quiz" target="_blank" rel="noopener">GitHub 原始碼</a>

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // 離線快取:app shell + 題庫。stale-while-revalidate(先給快取、背景更新)。
 // 改版要更新快取時,把 CACHE 版號 +1。
-const CACHE = 'ipas-v22';
+const CACHE = 'ipas-v23';
 const SHELL = ['./', 'index.html', 'app.js', 'core.js', 'manifest.json', 'favicon.svg', 'questions.json', 'concepts.json', 'icon-192.png', 'icon-512.png'];
 
 self.addEventListener('install', (e) => {


### PR DESCRIPTION
回應使用者:加方便看考試資訊的入口。

連到官方 [exam-info 頁](https://ipd.nat.gov.tw/ipas/certification/AIAP/exam-info)(2026 四個考試日期、及格標準=平均70且每科≥60、電腦測驗)。

**用連結不在站內複製**:那些是逐年變動的具體日期,連官方頁永遠最新、零維護(站內複製會過期)。放 footer 第一個,對考生最相關。sw.js CACHE v22→v23。

🤖 Generated with [Claude Code](https://claude.com/claude-code)