### PR TITLE
趨勢圖每根 bar 標出題數(純數字)

### DIFF
--- a/app.js
+++ b/app.js
@@ -568,7 +568,11 @@ function stats() {
   for (let i = 13; i >= 0; i--) { const d = new Date(today() + 'T00:00:00'); d.setDate(d.getDate() - i); days14.push(ymd(d)); }
   const hist = store.history || {};
   const maxA = Math.max(1, ...days14.map((d) => (hist[d] && hist[d].a) || 0));
-  const bars = days14.map((d) => `<div class="bar" style="height:${Math.round((((hist[d] && hist[d].a) || 0) / maxA) * 100)}%" title="${d}:${(hist[d] && hist[d].a) || 0} 題"></div>`).join('');
+  const bars = days14.map((d) => {
+    const a = (hist[d] && hist[d].a) || 0;
+    const h = a ? Math.max(3, Math.round((a / maxA) * 56)) : 0;
+    return `<div class="tcol" title="${d}：${a} 題"><span class="tnum">${a || ''}</span><div class="bar" style="height:${h}px"></div></div>`;
+  }).join('');
   view.innerHTML = `
     <section class="card">
       <h2>學習統計</h2>

--- a/index.html
+++ b/index.html
@@ -111,8 +111,10 @@
   .badges { display:flex; flex-wrap:wrap; gap:8px; margin:6px 0 14px; }
   .badge { font-size:13px; padding:6px 10px; border-radius:999px; background:#ecfdf5; color:#047857; border:1px solid #a7f3d0; }
   .badge.lock { background:#f3f4f6; color:#9ca3af; border-color:#e5e7eb; }
-  .trend { display:flex; align-items:flex-end; gap:4px; height:64px; margin:8px 0 4px; }
-  .trend .bar { flex:1; background:var(--c-accent); border-radius:3px 3px 0 0; min-height:2px; opacity:.85; }
+  .trend { display:flex; align-items:flex-end; gap:3px; height:78px; margin:8px 0 4px; }
+  .tcol { flex:1; height:100%; display:flex; flex-direction:column; justify-content:flex-end; align-items:center; gap:2px; }
+  .tnum { font-size:10px; color:var(--c-muted); font-variant-numeric:tabular-nums; line-height:1; min-height:11px; }
+  .trend .bar { width:100%; background:var(--c-accent); border-radius:3px 3px 0 0; opacity:.85; }
   .trend-lab { display:flex; justify-content:space-between; font-size:11px; color:var(--c-muted); }
   .code { font-family:ui-monospace,monospace; font-size:20px; background:#f8fafc; padding:10px; border-radius:8px; text-align:center; letter-spacing:1px; }
   h3.danger, button.danger { color:var(--c-bad); }

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // 離線快取:app shell + 題庫。stale-while-revalidate(先給快取、背景更新)。
 // 改版要更新快取時,把 CACHE 版號 +1。
-const CACHE = 'ipas-v24';
+const CACHE = 'ipas-v25';
 const SHELL = ['./', 'index.html', 'app.js', 'core.js', 'manifest.json', 'favicon.svg', 'questions.json', 'concepts.json', 'exam-dates.json', 'icon-192.png', 'icon-512.png'];
 
 self.addEventListener('install', (e) => {


### PR DESCRIPTION
回應使用者:最近 14 天趨勢圖每天沒寫幾題(原本只有 hover tooltip,手機看不到)。

- 把題數直接標在每根 bar 上方,**只顯示數字**(標題已寫「最近 14 天題數」,避免被當成 %)
- 0 題日不顯示數字、bar 高 0;bar 改 px 計算避免數字被擠
- 實測:8/20/5/12 正確標示、高度按比例(20=最高)
- sw.js CACHE v24→v25

🤖 Generated with [Claude Code](https://claude.com/claude-code)