### PR TITLE
筆記匯出補上完整選項(標出正解)

### DIFF
--- a/core.js
+++ b/core.js
@@ -80,11 +80,12 @@ export function toMarkdown(questions, progress, title = 'iPAS 筆記') {
     if (!p || (!p.starred && !p.note)) continue;
     n++;
     lines.push(`## ${n}. [${q.subject}] ${q.question}`);
-    lines.push(`- 正解：${q.options[q.answer]}`);
+    if (q.image) lines.push('- (此題含附圖,請對照站上題目)');
+    q.options.forEach((o, i) => lines.push(`- ${'ABCD'[i]}. ${o}${i === q.answer ? ' ✓（正解）' : ''}`));
     if (q.explanation) lines.push(`- 解析：${q.explanation}`);
     if (p.note) lines.push(`- 我的筆記：${p.note}`);
     lines.push('');
   }
-  if (n === 0) lines.push('_(還沒有星標的題目)_');
+  if (n === 0) lines.push('_(還沒有星標或筆記的題目)_');
   return lines.join('\n');
 }

--- a/core.test.mjs
+++ b/core.test.mjs
@@ -44,7 +44,8 @@ assert.deepEqual(wrongQuestionIds(qs, prog), ['b']);
 // markdown 匯出(收星標)
 const md = toMarkdown(qs, { c: { starred: true, note: '記得 RAG' } });
 assert.ok(md.includes('[S2]'));
-assert.ok(md.includes('正解：y'));
+assert.ok(md.includes('A. x'), '要列出所有選項');
+assert.ok(md.includes('B. y ✓（正解）'), '正解選項要標 ✓');
 assert.ok(md.includes('我的筆記：記得 RAG'));
 assert.ok(!md.includes('qa'), '沒星標也沒筆記的不該出現');
 

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // 離線快取:app shell + 題庫。stale-while-revalidate(先給快取、背景更新)。
 // 改版要更新快取時,把 CACHE 版號 +1。
-const CACHE = 'ipas-v25';
+const CACHE = 'ipas-v26';
 const SHELL = ['./', 'index.html', 'app.js', 'core.js', 'manifest.json', 'favicon.svg', 'questions.json', 'concepts.json', 'exam-dates.json', 'icon-192.png', 'icon-512.png'];
 
 self.addEventListener('install', (e) => {


### PR DESCRIPTION
回應使用者:匯出的 md 只有題目和正解、少了選項。原本 `toMarkdown` 只印正解那一行,非刻意排除。

- 改成列出 A/B/C/D **全部選項**,正解標 `✓（正解）`
- 帶圖題加提示「(此題含附圖,請對照站上題目)」(下載的 md 無法載入站上相對路徑圖)
- core.test 同步更新、PASS
- sw.js CACHE v25→v26

🤖 Generated with [Claude Code](https://claude.com/claude-code)