### PR TITLE
重設統計(保留筆記與星標)軟重設

### DIFF
--- a/app.js
+++ b/app.js
@@ -677,6 +677,10 @@ function settings() {
       <input id="imp" type="file" accept="application/json" hidden>
       <button id="exp-md">匯出筆記（Markdown）</button>
 
+      <h3>重設統計</h3>
+      <p class="muted" style="font-size:13px">把作答統計歸零、重新練到 100%,但<strong>保留你的筆記與星標</strong>。</p>
+      <button id="reset-stats">重設統計(保留筆記與星標)</button>
+
       <h3 class="danger">重設</h3>
       <button class="danger" id="reset">清除本機所有進度</button>
     </section>`;
@@ -762,6 +766,16 @@ function settings() {
   };
   $('#reset').onclick = () => {
     if (confirm('確定清除本機所有作答進度與筆記？')) { store = { v: 1, syncCode: makeCode(), q: {} }; save(); settings(); }
+  };
+  $('#reset-stats').onclick = () => {
+    if (!confirm('重設統計?掌握度、正確率、錯題本、打卡、趨勢都歸零;保留筆記、星標與設定。')) return;
+    for (const id in store.q) {
+      const p = store.q[id];
+      if (p.note || p.starred) store.q[id] = { box: 1, attempts: 0, correct: 0, wrong: 0, note: p.note || '', starred: !!p.starred };
+      else delete store.q[id];
+    }
+    store.recent = []; store.history = {}; store.streak = { count: 0, lastDate: '' }; store.daily = null;
+    save(); settings();
   };
 }
 

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // 離線快取:app shell + 題庫。stale-while-revalidate(先給快取、背景更新)。
 // 改版要更新快取時,把 CACHE 版號 +1。
-const CACHE = 'ipas-v34';
+const CACHE = 'ipas-v35';
 const SHELL = ['./', 'index.html', 'build.html', 'app.js', 'core.js', 'manifest.json', 'favicon.svg', 'questions.json', 'concepts.json', 'exam-dates.json', 'icon-192.png', 'icon-512.png'];
 
 self.addEventListener('install', (e) => {


### PR DESCRIPTION
回應使用者:整體正確率錯過就回不到 100%,完美主義者不舒服。加軟重設讓統計歸零、重新練到 100%。

- 設定頁加「重設統計(保留筆記與星標)」:歸零 box/attempts/correct/wrong + recent/history/streak → 掌握/正確率/錯題本/打卡/趨勢全 0
- **保留筆記與星標**(有 note/star 的題只清統計、純統計的題刪掉)
- 與既有「清除所有進度」分開
- sw v34→v35

實測:有筆記題統計歸零但 note/starred 保留、純統計題被刪、recent/history/streak 歸零。

🤖 Generated with [Claude Code](https://claude.com/claude-code)