### PR TITLE
fix(worker): 壞百分號編碼的 /sync 路徑回 400 而非拋例外

### DIFF
--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -34,7 +34,8 @@ export default {
     // ---- 同步 ----
     const sm = url.pathname.match(/^\/sync\/([^/]+)$/);
     if (sm) {
-      const code = decodeURIComponent(sm[1]);
+      let code;
+      try { code = decodeURIComponent(sm[1]); } catch { return json({ error: 'bad_code' }, 400); } // 壞的百分號編碼(爬蟲亂打)別讓 worker 拋例外
       if (!CODE_RE.test(code)) return json({ error: 'bad_code' }, 400);
       const key = 's:' + code.toLowerCase();
       if (req.method === 'GET') {


### PR DESCRIPTION
decodeURIComponent 遇到畸形編碼(/sync/% 等爬蟲亂打)會丟 URIError、
沒人接 → scriptThrewException(1101 / HTTP 500),污染錯誤統計。
包 try/catch,壞編碼直接回 bad_code 400。已部署 + curl 驗證。

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
