### PR TITLE
chore(worker): 拔除 KV 唯讀 fallback,存放收斂為 D1 單一來源

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ CLI 會擋掉:選項不是 4 個、answer 超範圍、缺必填、題幹重複�
 - **改學習邏輯**:在 `core.js`——`MASTER_BOX`(連對幾次算掌握)、`nextBox`(Leitner)、`reviewPriority`(智慧複習出題優先序)。改完務必更新並跑 `core.test.mjs`。
 - **改練習範圍維度**:`app.js` 的 `rangeKey()`(目前 = `chapter || subject`)。
 - **自架同步/推播後端**(fork 自己用):需要自己的 Cloudflare Worker + D1 + VAPID 金鑰。
-  1. `cd worker && npm i`,`wrangler d1 create ipas-quiz-sync` 把 database_id 填進 `wrangler.toml`,`wrangler d1 execute ipas-quiz-sync --remote --file schema.sql` 建表;`wrangler.toml` 裡的 `[[kv_namespaces]]` 區塊整個刪掉(本站 KV→D1 遷移的過渡 fallback,自架用不到)。
+  1. `cd worker && npm i`,`wrangler d1 create ipas-quiz-sync` 把 database_id 填進 `wrangler.toml`,`wrangler d1 execute ipas-quiz-sync --remote --file schema.sql` 建表。
   2. `npx web-push generate-vapid-keys` → 公鑰填 `wrangler.toml [vars] VAPID_PUBLIC` 與 `app.js` 的 `VAPID_PUBLIC`;私鑰 `wrangler secret put VAPID_PRIVATE`。
   3. `wrangler deploy`,把 worker 網址填進 `app.js` 的 `SYNC_URL`。
   - `SYNC_URL` 留空 = 純本機(同步/推播自動停用,站仍可用)。

--- a/README.md
+++ b/README.md
@@ -90,11 +90,11 @@ npx web-push generate-vapid-keys               # VAPID 金鑰
 npx wrangler deploy                            # 取得 https://<name>.<帳號>.workers.dev
 ```
 
-再把 worker 網址填進 `app.js` 最上面的 `SYNC_URL`,push。fork 自架的人把 `wrangler.toml` 裡的 `[[kv_namespaces]]` 區塊整個刪掉（那是本站從 KV 遷移到 D1 的過渡 fallback）。
+再把 worker 網址填進 `app.js` 最上面的 `SYNC_URL`,push。
 
 - 同步：背景自動（debounce 5 秒、切走 App、開設定頁時上傳）；換裝置在「設定」輸入同步碼一次即可。
 - 推播:Worker 用 `[triggers] crons = ["0 * * * *"]` 每小時檢查,到點且當天沒練就發。
-- 免費額度很夠；存放走 D1（免費層寫入 10 萬列/天）。早期用 KV 時 1,000 次寫入/天被真實流量吃滿過，2026-07 遷來 D1。
+- 免費額度很夠；存放走 D1（免費層寫入 10 萬列/天）。
 
 ## 擴充題庫 / 貢獻（給人 & AI 代理）
 

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -1,6 +1,5 @@
 // 後端:① 同步碼進度同步(/sync/:code)② Web Push 每日提醒(/push/* + cron)
-// 存放:D1(kv 表)。KV binding 只剩唯讀 fallback(2026-07 從 KV 遷來,免費層每日 1000 次寫入被刷題流量吃滿);
-// 等 D1 收斂(backfill 完+跑一陣子)就可以把 SYNC binding 和 fallback 一起拔掉。
+// 存放:D1(kv 表)。
 import { ApplicationServerKeys, generatePushHTTPRequest } from 'webpush-webcrypto';
 
 const CODE_RE = /^[a-z]+-[a-z]+-\d{2,4}$/i;
@@ -15,19 +14,16 @@ const json = (obj, status = 200) =>
 
 const ymdUTC = (d) => `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`;
 
-// ---- 存取層:D1 為主,舊 KV 資料唯讀 fallback ----
+// ---- 存取層:D1 ----
 async function readKey(env, key) {
   const row = await env.DB.prepare('SELECT value FROM kv WHERE key = ?1').bind(key).first();
-  if (row) return row.value;
-  return env.SYNC ? env.SYNC.get(key) : null; // ponytail: 遷移過渡,拔 KV binding 時連這行一起刪
+  return row ? row.value : null;
 }
 const writeKey = (env, key, value) =>
   env.DB.prepare('INSERT INTO kv (key, value, updated_at) VALUES (?1, ?2, ?3) ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at')
     .bind(key, value, Date.now()).run();
-async function deleteKey(env, key) {
-  await env.DB.prepare('DELETE FROM kv WHERE key = ?1').bind(key).run();
-  if (env.SYNC) await env.SYNC.delete(key); // 舊 KV 也刪,免得 fallback 把退訂的又撿回來
-}
+const deleteKey = (env, key) =>
+  env.DB.prepare('DELETE FROM kv WHERE key = ?1').bind(key).run();
 
 async function sendPush(env, sub, payloadObj) {
   const keys = await ApplicationServerKeys.fromJSON({ publicKey: env.VAPID_PUBLIC, privateKey: env.VAPID_PRIVATE });

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -11,12 +11,6 @@ binding = "DB"
 database_name = "ipas-quiz-sync"
 database_id = "a861f54c-1a47-4ede-9910-bd38bb8f5f4d"
 
-# 舊 KV(2026-07 遷去 D1 前的資料)——只當唯讀 fallback,收斂後可整塊刪掉。
-# fork 自架的人:直接刪這塊(worker 沒綁 SYNC 也能跑)。
-[[kv_namespaces]]
-binding = "SYNC"
-id = "a38f175fd0bf48b0be7c8d997bc1cd04"
-
 # 每小時整點跑,檢查誰到提醒時間且今天還沒練
 [triggers]
 crons = ["0 * * * *"]


### PR DESCRIPTION
## 改了什麼

Closes #35

sync 存放 2026-07-16 遷 D1(#34)後跑穩約兩週,本 PR 收尾拔除 KV 唯讀 fallback:

- `worker/src/index.js`:移除 `readKey` 的 `env.SYNC` fallback、`deleteKey` 的 `env.SYNC.delete`、檔頭過渡註解(共三處,`grep env.SYNC` 已歸零)
- `worker/wrangler.toml`:移除整個 `[[kv_namespaces]]` 區塊(含註解)
- `README.md`:刪「fork 自架要刪 kv_namespaces」與「早期用 KV…」兩句
- `AGENTS.md`:自架後端步驟同步簡化

## 前置驗證(issue 要求:fallback 真的沒人在用)

- GraphQL 查 namespace `a38f175fd0bf48b0be7c8d997bc1cd04` 近 7 天 read ops = **1070,非零**;依 issue 指示先查原因:
  - KV read op 不論命中與否都計數;`readKey` 只在 D1 miss 時落到 KV,所以每次查不存在的同步碼(爬蟲亂打、404 查詢)都會 +1。
  - 實際比對:KV 全部 1261 keys 對 D1 1736 rows 做差集,**只有 3 個 key 不在 D1**:`s:prod-check-77`、`s:test-demo-99`、`s:test-test-11`——全是手動驗證/測試碼(真實同步碼為隨機字組),非真實使用者。
  - 結論:fallback 已不服務任何真實使用者資料,read ops 非零純為 miss 落穿計數,可安全拔除。
- 上述 3 個測試 key 未 backfill、未動 prod 資料;KV namespace 本體暫留(等於保留舊資料備份),要刪由人工在 Cloudflare dashboard 執行。

## 提交前自查

- [x] `node core.test.mjs` 通過(PASS)
- [x] `node tools/check-questions.mjs` 通過(全部通過;114-2-m-s2-q45 提示為既有項目,非本次引入)
- [x] `questions.json` 未動,JSON 合法
- [x] 本次只動 worker 與文件,不在 SW 快取清單內,無需 bump `sw.js` 版號
- [x] 未動章節分類
- [x] 未動題庫答案
- [x] 沒 commit `worker/node_modules`、`worker/.wrangler`、任何金鑰

## 備註

- **07-30 後人工合併 + `cd worker && npx wrangler deploy`;本 PR 不開 auto-merge、不先部署。**
- deploy 後驗收(照 issue):prod PUT/GET roundtrip 一次 + 隔天看 KV ops 全零。
- worker 無自動化測試(`package.json` 無 test script),行為驗證靠 deploy 後 roundtrip。

🤖 Generated with [Claude Code](https://claude.com/claude-code)