### PR TITLE
fix(sw): activate 只清自己前綴的快取,別掃掉同 origin 其他站

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -18,7 +18,9 @@ self.addEventListener('install', (e) => {
   })());
 });
 self.addEventListener('activate', (e) => {
-  e.waitUntil(caches.keys().then((ks) => Promise.all(ks.filter((k) => k !== CACHE).map((k) => caches.delete(k)))).then(() => self.clients.claim()));
+  // 只清自己的 ipas-*:CacheStorage 是 per-origin,yazelin.github.io 所有專案共用同一份,
+  // 無差別刪會把 gewu 的 33MB、neko 等別站的離線包整包清掉,而且毫無徵兆。
+  e.waitUntil(caches.keys().then((ks) => Promise.all(ks.filter((k) => k.startsWith('ipas-') && k !== CACHE).map((k) => caches.delete(k)))).then(() => self.clients.claim()));
 });
 // 推播:顯示通知
 self.addEventListener('push', (e) => {


### PR DESCRIPTION
CacheStorage 是 per-origin —— yazelin.github.io 底下所有專案共用同一份
(SW 的 scope 只管 fetch,管不到快取)。原本 activate 無差別刪掉「不是自己
現行版本」的快取,等於每次改版就把 gewu 的 33MB、neko、token-unlimited
等同 origin 站的離線包整包清空,而且功能完全正常、毫無徵兆。

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
